### PR TITLE
New release fix

### DIFF
--- a/snpm_pi_ANOVAwithinS.m
+++ b/snpm_pi_ANOVAwithinS.m
@@ -205,6 +205,7 @@ end
 % use 12 as a cut off. (2^nSubj*nSubj * 8bytes/element).  
 %-If user wants all perms, then random method would seem to take an
 % absurdly long time, so exact is used.
+%-If number of subjects is too large, abandon integer indexing
 
 if nSubj<=12 || ~bAproxTst                    % exact method
 
@@ -218,7 +219,7 @@ if nSubj<=12 || ~bAproxTst                    % exact method
     PiCond =[a,PiCond];
     
     if bAproxTst                 % pick random supsample of perms
-	tmp=randperm(size(PiCond,1)-1);
+	tmp=1+randperm(size(PiCond,1)-1);
 	PiCond=PiCond([1 tmp(1:nPiCond)],:);
     end	
     

--- a/snpm_pi_ANOVAwithinS.m
+++ b/snpm_pi_ANOVAwithinS.m
@@ -218,9 +218,8 @@ if nSubj<=12 || ~bAproxTst                    % exact method
     PiCond =[a,PiCond];
     
     if bAproxTst                 % pick random supsample of perms
-	tmp=randperm(size(PiCond,1));
-	PiCond=PiCond(tmp(1:nPiCond),:);
-        % Note we may have missed iCond!  We catch this below.	
+	tmp=randperm(size(PiCond,1)-1);
+	PiCond=PiCond([1 tmp(1:nPiCond)],:);
     end	
     
     % Set bhPerms=0. The reason is this:
@@ -229,7 +228,7 @@ if nSubj<=12 || ~bAproxTst                    % exact method
     % Another way to think about it is to always keep first subject as +1.
     bhPerms=0;
     
-else                                          % random method
+elseif nSubj<=53      % random method, using integer indexing
     
     d       = nPiCond-1;
     tmp     = pow2(0:nSubj-2)*iCond(1:(nSubj-1))';  % Include correctly labeled iCond
@@ -248,6 +247,16 @@ else                                          % random method
     
     a = ones(size(PiCond,1),1);
     PiCond =[a,PiCond]; 
+    
+    bhPerms=0;    
+
+else    % random method, for nSubj>=54, when exceeding
+        % double-precision's significand's 53 bit precision
+        % For now, don't check for duplicates
+    
+    d       = nPiCond-1;
+    PiCond  = [iCond;
+	       2*(rand(nPiCond-1,nSubj)>0.5)-1];
     
     bhPerms=0;    
 
@@ -271,11 +280,6 @@ if length(perm)==1
 	% Allows interim analysis	
 	PiCond=[PiCond(1,:);PiCond(randperm(size(PiCond,1)-1)+1,:)];
     end	
-elseif length(perm)==0 && ~(nSubj<=12 || ~bAproxTst)
-    % Special case where random method missed iCond; order of perms is
-    % random so can we can just replace first perm.
-    PiCond(1,:) = iCond;
-    perm = 1;
 else    
     error('SnPM:InvalidPiCond', ['Bad PiCond (' num2str(perm) ')'])
 end    

--- a/snpm_pi_OneSampT.m
+++ b/snpm_pi_OneSampT.m
@@ -174,6 +174,7 @@ snpm_check_nperm(nPiCond,nPiCond_mx);
 % use 12 as a cut off. (2^nScan*nScan * 8bytes/element).  
 %-If user wants all perms, then random method would seem to take an
 % absurdly long time, so exact is used.
+%-If number of subjects/scans is too large, abandon integer indexing
 
 if nScan<=12 || ~bAproxTst                    % exact method
 
@@ -189,9 +190,8 @@ if nScan<=12 || ~bAproxTst                    % exact method
 	PiCond=PiCond(PiCond(:,1)==1,:);
 	bhPerms=1;
     elseif bAproxTst                 % pick random supsample of perms
-	tmp=randperm(size(PiCond,1));
-	PiCond=PiCond(tmp(1:nPiCond),:);
-        % Note we may have missed iCond!  We catch this below.	
+	tmp=1+randperm(size(PiCond,1)-1);
+	PiCond=PiCond([1 tmp(1:nPiCond-1)],:);
     end	
 
 elseif nScan<=53      % random method, using integer indexing
@@ -244,13 +244,8 @@ if length(perm)==1
 	% Allows interim analysis	
 	PiCond=[PiCond(1,:);PiCond(randperm(size(PiCond,1)-1)+1,:)];
     end	
-elseif length(perm)==0 && (nScan<=12) && bAproxTst
-    % Special case where we missed iCond; order of perms is random 
-    % so can we can just replace first perm.
-    PiCond(1,:) = iCond;
-    perm = 1;
 else    
-    error('SnPM:PiCond', ['Bad PiCond (' num2str(perm) ')'])
+    error('SnPM:InvalidPiCond', ['Bad PiCond (' num2str(perm) ')'])
 end    
 
 


### PR DESCRIPTION
This PR fixes problems identified by @cmaumet in https://github.com/SnPM-toolbox/SnPM-devel/pull/70.

The problem was that a previous fix to snpm_pi_ANOVAwithinS.m (#61, https://github.com/SnPM-toolbox/SnPM-devel/pull/61/commits/e38507307c12ee29cbfe98eed9a498c44b463b77) had a faulty logic; intended as a fix for large N, it only removed the error without really fixing the problem (that large nSubj produces integer overflow that breaks the integer indexing approach to permutation enumeration).

This PR implements the same fix used for snpm_pi_OneSampT.m (https://github.com/SnPM-toolbox/SnPM-devel/commit/5db909e0c50bc0559cb14bdaa21f6b4782378c9b#diff-eda93a30e2ecbeac12bc63a8d718e9e6), which also had the integer overflow problem.

For both snpm_pi_ANOVAwithinS.m and snpm_pi_OneSampT.m the logic has been changed slightly, so the original, no-permutation permutation is always included when permutations are crafted; as a result no 'last minute' check is needed.

Finally, both programs had a crash-out in case of a logic error (unpermuted data missing from PiCond), but it was inconsistently labeled (`SnPM:PiCond` in snpm_pi_OneSampT.m, `SnPM:InvalidPiCond` in snpm_pi_ANOVAwithinS.m; I changed this so that both use SnPM:InvalidPiCond.